### PR TITLE
unicode minteken vervangen door ascii minteken

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -116,7 +116,7 @@ We gebruiken de methode van Jacobi om een nulpunt te vinden.
 \newpage
 
 \section{Veeltermen met zo laag mogelijke graad}
-\paragraph{Gegeven:} Veelterm $p(x)$ met $p( − 1) = p(0) = p(1)$ en $p'(0) = 1$
+\paragraph{Gegeven:} Veelterm $p(x)$ met $p( - 1) = p(0) = p(1)$ en $p'(0) = 1$
 \paragraph{Gevraagd:} Geef alle veeltermen van zo laag mogelijke graad die hieraan voldoen.
 \paragraph{Informatie:} Zie p.122, methode der onbepaalde coëfficiënten
 \paragraph{Antwoord:}


### PR DESCRIPTION
Een foute formattering van het minteken zorgde ervoor dat bij compileren met latexmk het minteken niet tevoorschijn kwam. Dit is nu opgelost.