### PR TITLE
Tekenfouten in antwoord 7 opgelost

### DIFF
--- a/antwoorden/antwoord7.tex
+++ b/antwoorden/antwoord7.tex
@@ -8,7 +8,7 @@ We beginnen met P(-1) = c (met c een waarde die we niet kennen). We krijgen onze
 Voor P(0) weten we dat P(0) = P(-1) = c. We krijgen: \\
 \indent $ a_0 = c $ \\
 Voor P(1) weten we ook dat P(1) = c. We krijgen de 3de vergelijking: \\
-\indent $ a_0 + a_1 + a_2 - a_3 = c $ \\
+\indent $ a_0 + a_1 + a_2 + a_3 = c $ \\
 Als laatste weten we nog dan P'(0) = 1. De afgeleide van onze algemene functie = $ a_1 + 2a_2x + 3a_3x^2$ \\
 Hier vullen we 0 in, dan moet dit gelijk zijn aan 1: \\
 \indent $ a_1 = 1$ \\
@@ -19,7 +19,7 @@ Hiermee kunnen we volgend stelsel opstellen: \\
     \begin{array}{ccccccccc}
 		a_0 & - & a_1 & + & a_2 & - & a_3 & = & c \\
 							  &&&&&& a_0 & = & c \\
-		a_0 & + & a_1 & + & a_2 & - & a_3 & = & c \\
+		a_0 & + & a_1 & + & a_2 & + & a_3 & = & c \\
 		                      &&&&&& a_1 & = & 1 \\
     \end{array}
 \right.
@@ -28,6 +28,6 @@ Hiermee kunnen we volgend stelsel opstellen: \\
 
 Hieruit halen we dat $a_1$ = 1 \\
 Wanneer we dit stelsel verder uitwerken krijgen we volgende waarden:
-$a_1$ = 1 , $a_3$ = 1 , $a_2$ = 0  en P(0) = c\\
+$a_1$ = 1 , $a_2$ = 0 , $a_3$ = -1  en $a_0$ = c\\
 Dit levert: \\
-$c+x-x^3$
+p(x) = $c+x-x^3$


### PR DESCRIPTION
De derde vergelijking van de matrix had een tekenfout, je kan dit gemakkelijk controleren door gewoon x= 1 in te vullen in: a0 + a1*x+a2*x^2+a3*x^3 = c, dan krijg je een vergelijking met alleen maar positieve tekens.

Hierdoor stond er ook een fout in de uitgekomen coeëfficienten. De uitgekomen vergelijking was echter wel juist.

Je kan eenvoudig controleren dat de oplossingen van het stelsel juist zijn door a0= c, a1 = 1, a2=0, a3= -1 in het stelsel in te vullen.